### PR TITLE
Add GPU-enabled Docker support (Phase 6)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Secrets (mounted at runtime, never baked into image)
+.env
+credentials.json
+processed_files.json
+
+# Runtime data
+logs/
+tmp/
+samples/
+
+# Development / CI
+tests/
+docs/
+rpi/
+reports/
+.claude/
+.git/
+.gitignore
+.pytest_cache/
+venv/
+__pycache__/
+*.pyc
+*.egg-info/
+dist/
+build/
+
+# Docker files themselves
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Config (mounted at runtime)
+config.yaml
+
+# Misc
+README.md
+discord-minutes-bot.service
+start.sh
+requirements-dev.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# ============================================================
+# Discord Minutes Bot - GPU-enabled Docker image
+# ============================================================
+# Base: NVIDIA CUDA 12.6 + cuDNN runtime on Ubuntu 24.04
+# Python 3.12 ships natively with Ubuntu 24.04.
+#
+# The NVIDIA base image provides CUDA/cuDNN libraries at the
+# system level, so the LD_LIBRARY_PATH workaround used by
+# start.sh (for nvidia pip packages) is NOT needed here.
+# ============================================================
+
+FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Ensure Python output is sent straight to the container logs
+ENV PYTHONUNBUFFERED=1
+# Store Whisper model cache under /app (works regardless of user)
+ENV HF_HOME=/app/.cache/huggingface
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root user for runtime
+RUN useradd -r -m -s /bin/false botuser
+
+WORKDIR /app
+
+# Install Python dependencies first (Docker layer caching)
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir --break-system-packages -r requirements.txt
+
+# Copy application code
+COPY bot.py ./
+COPY src/ src/
+COPY prompts/ prompts/
+
+# Create runtime directories and set ownership
+RUN mkdir -p logs .cache/huggingface && chown -R botuser:botuser /app
+
+USER botuser
+
+CMD ["python3", "bot.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+# ============================================================
+# Discord Minutes Bot - Docker Compose (GPU)
+# ============================================================
+# Prerequisites:
+#   - Docker Engine with Compose V2
+#   - nvidia-container-toolkit installed and configured
+#   - .env file with DISCORD_BOT_TOKEN and ANTHROPIC_API_KEY
+#   - config.yaml configured with guild/channel IDs
+#   - credentials.json (Google service account key, if Drive watcher enabled)
+#   - touch processed_files.json   (create empty file before first run)
+#
+# Usage:
+#   docker compose up -d --build
+#   docker compose logs -f
+#   docker compose down
+# ============================================================
+
+services:
+  bot:
+    build: .
+    container_name: discord-minutes-bot
+    restart: on-failure
+
+    # Mount secrets and config (not baked into image)
+    volumes:
+      - ./.env:/app/.env:ro
+      - ./config.yaml:/app/config.yaml:ro
+      - ./credentials.json:/app/credentials.json:ro
+      - ./processed_files.json:/app/processed_files.json
+      - ./logs:/app/logs
+      # Persist Whisper model cache across container restarts (~3 GB)
+      - whisper-cache:/app/.cache/huggingface
+
+    # GPU access via nvidia-container-toolkit
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+volumes:
+  whisper-cache:

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+export LD_LIBRARY_PATH="$(python3 -c 'import nvidia.cublas, nvidia.cudnn; print(nvidia.cublas.__path__[0] + "/lib:" + nvidia.cudnn.__path__[0] + "/lib")")${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+exec python3 "$SCRIPT_DIR/bot.py"


### PR DESCRIPTION
Dockerfile with NVIDIA CUDA 12.6 + cuDNN runtime base, Python 3.12, non-root user, and docker-compose.yml with nvidia-container-toolkit GPU reservation and volume mounts for config/secrets/model cache.