### PR TITLE
Phase 6-7: Docker support, Craig API POST job start, mention feature

### DIFF
--- a/src/craig_client.py
+++ b/src/craig_client.py
@@ -115,9 +115,11 @@ class CraigClient(AudioSource):
         """
         payload = {
             "type": "recording",
-            "format": self._cfg.cook_format,
-            "container": self._cfg.cook_container,
-            "dynaudnorm": False,
+            "options": {
+                "format": self._cfg.cook_format,
+                "container": self._cfg.cook_container,
+                "dynaudnorm": False,
+            },
         }
         logger.info(
             "Starting cook job for recording %s (format=%s, container=%s)",

--- a/tests/test_craig_client.py
+++ b/tests/test_craig_client.py
@@ -156,9 +156,9 @@ async def test_start_job_sends_post_with_format(
             assert len(calls) == 1
             body = calls[0].kwargs.get("json", {})
             assert body["type"] == "recording"
-            assert body["format"] == "aac"
-            assert body["container"] == "zip"
-            assert body["dynaudnorm"] is False
+            assert body["options"]["format"] == "aac"
+            assert body["options"]["container"] == "zip"
+            assert body["options"]["dynaudnorm"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **Phase 6**: GPU-enabled Docker support (Dockerfile, docker-compose.yml, .dockerignore, start.sh)
- **Phase 7**: Add POST request to Craig Cook API to start job before GET polling (without POST, polling never sees a running job)
- **Mention feature**: `mention_user_ids` in config.yaml poster section for @mentioning users on minutes post
- **Craig API POST body fixes**: Corrected structure to `{"type":"recording","options":{"format":"aac","container":"zip","dynaudnorm":false}}`
- **Pipeline**: Added `processing_timeout_sec` config and `asyncio.timeout` wrapper

## Test plan
- [x] All 12 craig_client tests pass (POST body structure, polling, download, error cases)
- [x] All 22 poster tests pass (embed formatting, mentions, error embed)
- [x] Full test suite (114 tests) passes
- [ ] Live test: verify Craig API accepts the nested options POST body

🤖 Generated with [Claude Code](https://claude.com/claude-code)