### PR TITLE
Fix detailed-minutes-format review findings

### DIFF
--- a/src/merger.py
+++ b/src/merger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from src.config import MergerConfig
 from src.transcriber import Segment
@@ -118,7 +119,6 @@ def format_transcript_markdown(
     ]
 
     # Parse [MM:SS] or [HH:MM:SS] prefix to total seconds
-    import re
     ts_pattern = re.compile(r"^\[(?:(\d+):)?(\d+):(\d+)\]\s*(.+)$")
 
     current_section_start: int | None = None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -159,7 +159,7 @@ def mock_generator() -> MagicMock:
     g = MagicMock()
     g.is_loaded = True
     g.generate = AsyncMock(
-        return_value="# 会議議事録\n## 要約\nテスト会議\n## 決定事項\n- テスト"
+        return_value="# 会議議事録\n## まとめ\nテスト会議\n## 推奨される次のステップ\n- [ ] テスト"
     )
     return g
 
@@ -522,6 +522,81 @@ class TestPipelineSpeakerAnalytics:
         mock_post.assert_called_once()
         call_kwargs = mock_post.call_args.kwargs
         assert call_kwargs["speaker_stats"] is None
+
+
+class TestPipelineTranscriptAttachment:
+    @pytest.mark.asyncio
+    async def test_transcript_md_passed_when_enabled(
+        self,
+        recording: DetectedRecording,
+        mock_session: MagicMock,
+        mock_channel: MagicMock,
+        mock_transcriber: MagicMock,
+        mock_generator: MagicMock,
+        state_store: StateStore,
+        tmp_path: Path,
+    ) -> None:
+        """When include_transcript=True, transcript_md is passed to post_minutes."""
+        cfg = _make_config(poster=PosterConfig(include_transcript=True))
+        tracks = _make_tracks(tmp_path)
+
+        with (
+            patch("src.pipeline._stage_download", new_callable=AsyncMock) as mock_dl,
+            patch("src.pipeline.post_minutes", new_callable=AsyncMock) as mock_post,
+        ):
+            mock_dl.return_value = tracks
+            mock_post.return_value = MagicMock(id=1)
+
+            await run_pipeline(
+                recording=recording,
+                session=mock_session,
+                cfg=cfg,
+                transcriber=mock_transcriber,
+                generator=mock_generator,
+                output_channel=mock_channel,
+                state_store=state_store,
+            )
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args.kwargs
+        assert call_kwargs["transcript_md"] is not None
+        assert "# 文字起こし" in call_kwargs["transcript_md"]
+
+    @pytest.mark.asyncio
+    async def test_transcript_md_none_when_disabled(
+        self,
+        recording: DetectedRecording,
+        mock_session: MagicMock,
+        mock_channel: MagicMock,
+        mock_transcriber: MagicMock,
+        mock_generator: MagicMock,
+        state_store: StateStore,
+        tmp_path: Path,
+    ) -> None:
+        """When include_transcript=False (default), transcript_md is None."""
+        cfg = _make_config(poster=PosterConfig(include_transcript=False))
+        tracks = _make_tracks(tmp_path)
+
+        with (
+            patch("src.pipeline._stage_download", new_callable=AsyncMock) as mock_dl,
+            patch("src.pipeline.post_minutes", new_callable=AsyncMock) as mock_post,
+        ):
+            mock_dl.return_value = tracks
+            mock_post.return_value = MagicMock(id=1)
+
+            await run_pipeline(
+                recording=recording,
+                session=mock_session,
+                cfg=cfg,
+                transcriber=mock_transcriber,
+                generator=mock_generator,
+                output_channel=mock_channel,
+                state_store=state_store,
+            )
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args.kwargs
+        assert call_kwargs["transcript_md"] is None
 
 
 class TestTranscriptHash:


### PR DESCRIPTION
## Summary
- Add missing pipeline integration tests for `transcript_md` parameter (enabled/disabled paths)
- Move `import re` from function body to module level in `src/merger.py`
- Update mock generator fixture to use current section names (`まとめ`/`推奨される次のステップ`)

## Test plan
- [x] `pytest tests/test_merger.py tests/test_poster.py tests/test_pipeline.py` — 77 passed
- [x] New tests: `TestPipelineTranscriptAttachment` (2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)