### PR TITLE
Add OpenAI-compatible LLM backend (Ollama/vLLM/llama.cpp)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -57,6 +57,9 @@ merger:
   gap_merge_threshold_sec: 1.0
 
 generator:
+  # Backend: "claude" (default) or "openai_compat" (Ollama/vLLM/llama.cpp)
+  # backend: "openai_compat"
+  # base_url: "http://localhost:11434/v1"
   # Anthropic model for minutes generation
   model: "claude-sonnet-4-5-20250929"
   # Maximum tokens in the generated response

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 discord.py>=2.3,<3.0
 faster-whisper>=1.0,<2.0
 anthropic>=0.40,<1.0
+openai>=1.0,<2.0
 aiohttp>=3.9,<4.0
 PyYAML>=6.0,<7.0
 python-dotenv>=1.0,<2.0

--- a/src/config.py
+++ b/src/config.py
@@ -24,6 +24,8 @@ VALID_WHISPER_MODELS = frozenset({
     "large-v3-turbo",
 })
 
+VALID_GENERATOR_BACKENDS = frozenset({"claude", "openai_compat"})
+
 VALID_WHISPER_LANGUAGES = frozenset({
     "auto",
     "ja", "en", "zh", "ko",
@@ -98,6 +100,8 @@ class GeneratorConfig:
     temperature: float = 0.3
     prompt_template_path: str = "prompts/minutes.txt"
     max_retries: int = 2
+    backend: str = "claude"
+    base_url: str = ""
 
 
 @dataclass(frozen=True)
@@ -348,6 +352,15 @@ def _validate(cfg: Config) -> None:
         )
 
     # Generator
+    if cfg.generator.backend not in VALID_GENERATOR_BACKENDS:
+        errors.append(
+            f"generator.backend '{cfg.generator.backend}' is not valid. "
+            f"Choose from: {sorted(VALID_GENERATOR_BACKENDS)}"
+        )
+    if cfg.generator.backend == "openai_compat" and not cfg.generator.base_url:
+        errors.append(
+            "generator.base_url is required when generator.backend is 'openai_compat'"
+        )
     if not (0.0 <= cfg.generator.temperature <= 1.0):
         errors.append("generator.temperature must be between 0.0 and 1.0")
     if cfg.generator.max_tokens < 1:

--- a/src/generator.py
+++ b/src/generator.py
@@ -1,4 +1,4 @@
-"""Minutes generation via Anthropic Claude API."""
+"""Minutes generation via LLM API (Claude or OpenAI-compatible)."""
 
 from __future__ import annotations
 
@@ -14,6 +14,10 @@ from src.config import GeneratorConfig
 from src.errors import GenerationError
 
 logger = logging.getLogger(__name__)
+
+
+class _ApiRetryable(Exception):
+    """Backend-agnostic retryable API error."""
 
 
 @dataclass
@@ -58,6 +62,7 @@ class MinutesGenerator:
         self._templates: dict[str, str] = {}
         self._prompts_dir: Path | None = None
         self._client: anthropic.Anthropic | None = None
+        self._openai_client: object | None = None
 
     def load(self) -> None:
         """Load the default prompt template and initialise the API client.
@@ -75,11 +80,26 @@ class MinutesGenerator:
         self._templates[path.stem] = path.read_text(encoding="utf-8")
         logger.debug("Loaded prompt template from %s (%d chars)", path, len(self._templates[path.stem]))
 
-        if not self._cfg.api_key:
-            raise GenerationError("ANTHROPIC_API_KEY is not set")
-
-        self._client = anthropic.Anthropic(api_key=self._cfg.api_key)
-        logger.info("MinutesGenerator initialised (model=%s)", self._cfg.model)
+        if self._cfg.backend == "claude":
+            if not self._cfg.api_key:
+                raise GenerationError("ANTHROPIC_API_KEY is not set")
+            self._client = anthropic.Anthropic(api_key=self._cfg.api_key)
+        elif self._cfg.backend == "openai_compat":
+            try:
+                import openai
+            except ImportError:
+                raise GenerationError(
+                    "openai package is required for openai_compat backend. "
+                    "Install with: pip install openai"
+                )
+            self._openai_client = openai.OpenAI(
+                base_url=self._cfg.base_url,
+                api_key=self._cfg.api_key or "not-needed",
+            )
+        logger.info(
+            "MinutesGenerator initialised (backend=%s, model=%s)",
+            self._cfg.backend, self._cfg.model,
+        )
 
     def _load_template(self, name: str) -> str:
         """Load and cache a template by name. Raises GenerationError if not found."""
@@ -119,7 +139,9 @@ class MinutesGenerator:
 
     @property
     def is_loaded(self) -> bool:
-        return bool(self._templates) and self._client is not None
+        return bool(self._templates) and (
+            self._client is not None or self._openai_client is not None
+        )
 
     def render_prompt(
         self,
@@ -149,6 +171,71 @@ class MinutesGenerator:
         for placeholder, value in replacements.items():
             result = result.replace(placeholder, value)
         return result
+
+    async def _call_api(self, prompt: str) -> str:
+        """Dispatch to the configured backend."""
+        if self._cfg.backend == "claude":
+            return await self._call_claude_api(prompt)
+        return await self._call_openai_api(prompt)
+
+    async def _call_claude_api(self, prompt: str) -> str:
+        try:
+            response = await asyncio.to_thread(
+                self._client.messages.create,
+                model=self._cfg.model,
+                max_tokens=self._cfg.max_tokens,
+                temperature=self._cfg.temperature,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = response.content[0].text
+            logger.info(
+                "Claude: %d input tokens, %d output tokens",
+                response.usage.input_tokens,
+                response.usage.output_tokens,
+            )
+            return text
+        except anthropic.RateLimitError as exc:
+            raise _ApiRetryable(str(exc)) from exc
+        except anthropic.APIStatusError as exc:
+            if 400 <= exc.status_code < 500 and exc.status_code != 429:
+                raise GenerationError(
+                    f"Claude API client error (HTTP {exc.status_code}): {exc.message}"
+                ) from exc
+            raise _ApiRetryable(str(exc)) from exc
+        except anthropic.APIConnectionError as exc:
+            raise _ApiRetryable(str(exc)) from exc
+
+    async def _call_openai_api(self, prompt: str) -> str:
+        import openai
+
+        try:
+            response = await asyncio.to_thread(
+                self._openai_client.chat.completions.create,
+                model=self._cfg.model,
+                max_tokens=self._cfg.max_tokens,
+                temperature=self._cfg.temperature,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            if not response.choices:
+                raise GenerationError("API returned empty response (no choices)")
+            text = response.choices[0].message.content or ""
+            if response.usage:
+                logger.info(
+                    "OpenAI-compat: %d input tokens, %d output tokens",
+                    response.usage.prompt_tokens,
+                    response.usage.completion_tokens,
+                )
+            return text
+        except openai.RateLimitError as exc:
+            raise _ApiRetryable(str(exc)) from exc
+        except openai.APIStatusError as exc:
+            if 400 <= exc.status_code < 500 and exc.status_code != 429:
+                raise GenerationError(
+                    f"API client error (HTTP {exc.status_code}): {exc.message}"
+                ) from exc
+            raise _ApiRetryable(str(exc)) from exc
+        except openai.APIConnectionError as exc:
+            raise _ApiRetryable(str(exc)) from exc
 
     async def generate(
         self,
@@ -183,54 +270,23 @@ class MinutesGenerator:
             try:
                 t0 = time.monotonic()
                 logger.info(
-                    "Calling Claude API (attempt %d/%d, model=%s)",
+                    "Calling %s API (attempt %d/%d, model=%s)",
+                    self._cfg.backend,
                     attempt,
                     max_attempts,
                     self._cfg.model,
                 )
-
-                # Run synchronous Anthropic call in a thread to avoid
-                # blocking the async event loop.
-                response = await asyncio.to_thread(
-                    self._client.messages.create,
-                    model=self._cfg.model,
-                    max_tokens=self._cfg.max_tokens,
-                    temperature=self._cfg.temperature,
-                    messages=[{"role": "user", "content": prompt}],
-                )
-
+                text = await self._call_api(prompt)
                 elapsed = time.monotonic() - t0
-                text = response.content[0].text
                 logger.info(
-                    "Claude API responded in %.1fs (%d chars, %d input tokens, %d output tokens)",
-                    elapsed,
-                    len(text),
-                    response.usage.input_tokens,
-                    response.usage.output_tokens,
+                    "API responded in %.1fs (%d chars)", elapsed, len(text),
                 )
                 return text
 
-            except anthropic.RateLimitError as exc:
+            except _ApiRetryable as exc:
                 last_exc = exc
                 logger.warning(
-                    "Rate limited on attempt %d/%d: %s",
-                    attempt, max_attempts, exc,
-                )
-            except anthropic.APIStatusError as exc:
-                last_exc = exc
-                # 4xx (except 429) are not retryable
-                if 400 <= exc.status_code < 500 and exc.status_code != 429:
-                    raise GenerationError(
-                        f"Claude API client error (HTTP {exc.status_code}): {exc.message}"
-                    ) from exc
-                logger.warning(
-                    "API error on attempt %d/%d (HTTP %d): %s",
-                    attempt, max_attempts, exc.status_code, exc.message,
-                )
-            except anthropic.APIConnectionError as exc:
-                last_exc = exc
-                logger.warning(
-                    "Connection error on attempt %d/%d: %s",
+                    "Retryable error on attempt %d/%d: %s",
                     attempt, max_attempts, exc,
                 )
 
@@ -241,5 +297,5 @@ class MinutesGenerator:
                 await asyncio.sleep(delay)
 
         raise GenerationError(
-            f"Claude API failed after {max_attempts} attempts: {last_exc}"
+            f"API failed after {max_attempts} attempts: {last_exc}"
         ) from last_exc

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -212,6 +212,76 @@ class TestValidation:
             load(str(cfg_path), str(env_path))
 
 
+class TestGeneratorBackend:
+    def test_backend_default_is_claude(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+
+        cfg_path = _write_config(tmp_path, """
+            discord:
+              guild_id: 1
+              watch_channel_id: 2
+              output_channel_id: 3
+            """)
+        env_path = _write_env(tmp_path, "")
+
+        cfg = load(str(cfg_path), str(env_path))
+        assert cfg.generator.backend == "claude"
+
+    def test_invalid_generator_backend(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+
+        cfg_path = _write_config(tmp_path, """
+            discord:
+              guild_id: 1
+              watch_channel_id: 2
+              output_channel_id: 3
+            generator:
+              backend: "invalid"
+            """)
+        env_path = _write_env(tmp_path, "")
+
+        with pytest.raises(ConfigError, match="generator.backend"):
+            load(str(cfg_path), str(env_path))
+
+    def test_openai_compat_requires_base_url(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+
+        cfg_path = _write_config(tmp_path, """
+            discord:
+              guild_id: 1
+              watch_channel_id: 2
+              output_channel_id: 3
+            generator:
+              backend: "openai_compat"
+            """)
+        env_path = _write_env(tmp_path, "")
+
+        with pytest.raises(ConfigError, match="base_url is required"):
+            load(str(cfg_path), str(env_path))
+
+    def test_openai_compat_no_api_key_ok(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """openai_compat backend does not require ANTHROPIC_API_KEY."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+
+        cfg_path = _write_config(tmp_path, """
+            discord:
+              guild_id: 1
+              watch_channel_id: 2
+              output_channel_id: 3
+            generator:
+              backend: "openai_compat"
+              base_url: "http://localhost:11434/v1"
+            """)
+        env_path = _write_env(tmp_path, "")
+
+        cfg = load(str(cfg_path), str(env_path))
+        assert cfg.generator.backend == "openai_compat"
+        assert cfg.generator.base_url == "http://localhost:11434/v1"
+
+
 class TestWhisperLanguageValidation:
     def test_invalid_whisper_language_rejected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Invalid language code should raise ConfigError."""

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -13,8 +13,8 @@ from src.errors import GenerationError
 from src.generator import MinutesGenerator, TemplateInfo, _parse_template_metadata
 
 
-def _make_cfg(tmp_path: Path, api_key: str = "sk-test") -> GeneratorConfig:
-    """Create a GeneratorConfig with a real template file."""
+def _write_template(tmp_path: Path) -> Path:
+    """Write a template file and return its path."""
     template = tmp_path / "minutes.txt"
     template.write_text(
         "# name: Standard\n# description: Standard template\n"
@@ -23,7 +23,13 @@ def _make_cfg(tmp_path: Path, api_key: str = "sk-test") -> GeneratorConfig:
         "Transcript:\n{transcript}",
         encoding="utf-8",
     )
-    return GeneratorConfig(
+    return template
+
+
+def _make_cfg(tmp_path: Path, api_key: str = "sk-test", **kwargs) -> GeneratorConfig:
+    """Create a GeneratorConfig with a real template file."""
+    template = _write_template(tmp_path)
+    defaults = dict(
         api_key=api_key,
         model="claude-sonnet-4-5-20250929",
         max_tokens=1024,
@@ -31,6 +37,8 @@ def _make_cfg(tmp_path: Path, api_key: str = "sk-test") -> GeneratorConfig:
         prompt_template_path=str(template),
         max_retries=2,
     )
+    defaults.update(kwargs)
+    return GeneratorConfig(**defaults)
 
 
 class TestGeneratorLoad:
@@ -247,6 +255,135 @@ class TestParseTemplateMetadata:
         display, desc = _parse_template_metadata(p)
         assert display == "Only Name"
         assert desc == ""
+
+
+class TestOpenAICompat:
+    def test_load_openai_compat(self, tmp_path: Path) -> None:
+        cfg = _make_cfg(tmp_path, api_key="", backend="openai_compat",
+                        base_url="http://localhost:11434/v1")
+        gen = MinutesGenerator(cfg)
+        with patch("openai.OpenAI") as mock_cls:
+            gen.load()
+            mock_cls.assert_called_once_with(
+                base_url="http://localhost:11434/v1",
+                api_key="not-needed",
+            )
+        assert gen.is_loaded
+
+    def test_load_openai_compat_missing_package(self, tmp_path: Path) -> None:
+        cfg = _make_cfg(tmp_path, api_key="", backend="openai_compat",
+                        base_url="http://localhost:11434/v1")
+        gen = MinutesGenerator(cfg)
+        with patch.dict("sys.modules", {"openai": None}):
+            with pytest.raises(GenerationError, match="pip install openai"):
+                gen.load()
+
+    @pytest.mark.asyncio
+    async def test_generate_openai_compat_success(self, tmp_path: Path) -> None:
+        cfg = _make_cfg(tmp_path, api_key="", backend="openai_compat",
+                        base_url="http://localhost:11434/v1")
+        gen = MinutesGenerator(cfg)
+        gen.load()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="# 議事録\nテスト"))]
+        mock_response.usage = MagicMock(prompt_tokens=100, completion_tokens=50)
+        gen._openai_client.chat.completions.create = MagicMock(return_value=mock_response)
+
+        result = await gen.generate("transcript", "date", "speakers")
+        assert "議事録" in result
+
+    @pytest.mark.asyncio
+    async def test_generate_openai_compat_rate_limit(self, tmp_path: Path) -> None:
+        import openai as openai_mod
+
+        cfg = _make_cfg(tmp_path, api_key="", backend="openai_compat",
+                        base_url="http://localhost:11434/v1")
+        gen = MinutesGenerator(cfg)
+        gen.load()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Success"))]
+        mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+
+        rate_exc = openai_mod.RateLimitError(
+            message="rate limited",
+            response=MagicMock(status_code=429, headers={}),
+            body=None,
+        )
+
+        gen._openai_client.chat.completions.create = MagicMock(
+            side_effect=[rate_exc, mock_response]
+        )
+
+        result = await gen.generate("transcript", "date", "speakers")
+        assert result == "Success"
+        assert gen._openai_client.chat.completions.create.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_generate_openai_compat_client_error(self, tmp_path: Path) -> None:
+        import openai as openai_mod
+
+        cfg = _make_cfg(tmp_path, api_key="", backend="openai_compat",
+                        base_url="http://localhost:11434/v1")
+        gen = MinutesGenerator(cfg)
+        gen.load()
+
+        client_exc = openai_mod.APIStatusError(
+            message="bad request",
+            response=MagicMock(status_code=400, headers={}),
+            body=None,
+        )
+        gen._openai_client.chat.completions.create = MagicMock(side_effect=client_exc)
+
+        with pytest.raises(GenerationError, match="client error"):
+            await gen.generate("transcript", "date", "speakers")
+
+    @pytest.mark.asyncio
+    async def test_generate_openai_compat_connection_error(self, tmp_path: Path) -> None:
+        import openai as openai_mod
+
+        cfg = _make_cfg(tmp_path, api_key="", backend="openai_compat",
+                        base_url="http://localhost:11434/v1")
+        gen = MinutesGenerator(cfg)
+        gen.load()
+
+        conn_exc = openai_mod.APIConnectionError(request=MagicMock())
+        gen._openai_client.chat.completions.create = MagicMock(side_effect=conn_exc)
+
+        with pytest.raises(GenerationError, match="failed after"):
+            await gen.generate("transcript", "date", "speakers")
+
+        assert gen._openai_client.chat.completions.create.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_generate_openai_compat_empty_response(self, tmp_path: Path) -> None:
+        cfg = _make_cfg(tmp_path, api_key="", backend="openai_compat",
+                        base_url="http://localhost:11434/v1")
+        gen = MinutesGenerator(cfg)
+        gen.load()
+
+        mock_response = MagicMock()
+        mock_response.choices = []
+        gen._openai_client.chat.completions.create = MagicMock(return_value=mock_response)
+
+        with pytest.raises(GenerationError, match="empty response"):
+            await gen.generate("transcript", "date", "speakers")
+
+    @pytest.mark.asyncio
+    async def test_generate_openai_compat_no_usage(self, tmp_path: Path) -> None:
+        cfg = _make_cfg(tmp_path, api_key="", backend="openai_compat",
+                        base_url="http://localhost:11434/v1")
+        gen = MinutesGenerator(cfg)
+        gen.load()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Result"))]
+        mock_response.usage = None
+        gen._openai_client.chat.completions.create = MagicMock(return_value=mock_response)
+
+        result = await gen.generate("transcript", "date", "speakers")
+        assert result == "Result"
 
 
 class TestLoadTemplate:


### PR DESCRIPTION
## Summary
- `config.yaml` で `backend: "openai_compat"` + `base_url` を設定するだけでローカルLLM（Ollama, vLLM, llama.cpp等）に切り替え可能
- デフォルト `backend: "claude"` で既存環境に影響なし（完全後方互換）
- 起動時バリデーション、例外翻訳層（`_ApiRetryable`）、12件の新規テスト

## Changes
- `src/config.py`: `GeneratorConfig` に `backend`/`base_url` フィールド追加、バリデーション追加
- `src/generator.py`: `_call_claude_api()`/`_call_openai_api()` に分離、統一リトライ
- `requirements.txt`: `openai>=1.0,<2.0` 追加
- `config.yaml`: コメントアウトされた設定例追加
- `tests/test_config.py`: バックエンドバリデーションテスト4件
- `tests/test_generator.py`: openai_compatテスト8件

## Usage
```yaml
generator:
  backend: "openai_compat"
  base_url: "http://localhost:11434/v1"
  model: "qwen2.5:32b"
```

## Test plan
- [x] 既存Claudeパステスト全パス（リグレッションなし）
- [x] openai_compat新規テスト8件全パス
- [x] configバリデーションテスト4件全パス
- [x] 全体テスト262/264パス（2件はCUDA環境依存で無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)