### PR TITLE
Make watch_channel_id optional for guild-wide Craig detection

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,8 +10,8 @@ discord:
   # still supported for backward compatibility.
   guilds:
     - guild_id: 1027141726340657243
-      # Channel ID where Craig Bot posts recording messages
-      watch_channel_id: 1044060217882726470
+      # Channel ID where Craig Bot posts recording messages (0 = monitor all channels)
+      # watch_channel_id: 1044060217882726470
       # Channel ID where meeting minutes will be posted
       output_channel_id: 1395775686924570655
       # Per-guild error mention role (optional, overrides global setting)

--- a/src/config.py
+++ b/src/config.py
@@ -51,8 +51,8 @@ class GuildConfig:
     """Per-guild configuration (guild ID, watch channel, output channel)."""
 
     guild_id: int
-    watch_channel_id: int
     output_channel_id: int
+    watch_channel_id: int = 0  # 0 = monitor all channels in this guild
     template: str = "minutes"
     error_mention_role_id: int | None = None
     google_drive: GuildDriveConfig | None = None
@@ -394,8 +394,8 @@ def _validate(cfg: Config) -> None:
             errors.append(f"{prefix}.guild_id {guild.guild_id} is duplicated")
         else:
             seen_guild_ids.add(guild.guild_id)
-        if guild.watch_channel_id <= 0:
-            errors.append(f"{prefix}.watch_channel_id must be a positive integer")
+        if guild.watch_channel_id < 0:
+            errors.append(f"{prefix}.watch_channel_id must be 0 (all channels) or a positive integer")
         if guild.output_channel_id <= 0:
             errors.append(f"{prefix}.output_channel_id must be a positive integer")
 

--- a/src/detector.py
+++ b/src/detector.py
@@ -105,12 +105,12 @@ def parse_recording_ended(
     """Top-level detection: check all conditions and return DetectedRecording or None.
 
     Checks in order:
-      1. Channel matches the configured watch channel
+      1. Channel matches the configured watch channel (0 = any channel)
       2. Message is from Craig Bot
       3. Components indicate recording has ended
       4. A valid recording URL can be extracted
     """
-    if channel_id != watch_channel_id:
+    if watch_channel_id and channel_id != watch_channel_id:
         return None
 
     if not is_craig_message(payload_data):


### PR DESCRIPTION
## Summary
- `watch_channel_id` をオプショナルに変更（`0` または未指定でギルド全チャンネル監視）
- Craigの録音パネルは `/join` を実行したチャンネルに表示されるため、固定チャンネル監視だと検知漏れが発生していた
- 後方互換: 既存の `watch_channel_id` 指定はそのまま動作

## Test plan
- [x] 全365テスト合格（GPU依存2件除く）
- [ ] 実環境で複数チャンネルからのCraig録音検知を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)