### PR TITLE
Add markdown dependency for Google Docs export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyYAML>=6.0,<7.0
 python-dotenv>=1.0,<2.0
 google-api-python-client>=2.0,<3.0
 google-auth>=2.0,<3.0
+markdown>=3.4,<4.0


### PR DESCRIPTION
## Summary
- `markdown>=3.4,<4.0` を requirements.txt に追加
- `src/exporter.py` の Google Docs エクスポート機能で Markdown→HTML 変換に使用
- 既存コードは lazy import 済みだが、依存関係として明示化

## Test plan
- [x] 全367テスト合格
- [x] `test_exporter.py` 17テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)