### PR TITLE
Google Docs export: Gemini Meet風2タブ構成

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,6 +16,8 @@ from src.errors import ExportError
 logger = logging.getLogger(__name__)
 
 _SCOPES = ["https://www.googleapis.com/auth/drive.file"]
+
+TRANSCRIPT_TAB_PLACEHOLDER = "__TRANSCRIPT_TAB_URL__"
 
 
 @dataclass(frozen=True)
@@ -33,36 +36,193 @@ class GoogleDocsExporter:
     def __init__(self, cfg: ExportGoogleDocsConfig) -> None:
         self._cfg = cfg
         self._service: Any = None
+        self._docs_service: Any = None
 
     def _build_service(self) -> Any:
-        """Build and cache the Google Drive API v3 service client."""
+        """Build and cache the Google Drive API v3 service client.
+
+        Uses OAuth2 user credentials (token.json) if available, falling back
+        to service account credentials.  OAuth2 avoids the zero-quota issue
+        that service accounts have on personal Google accounts.
+        """
         if self._service is not None:
             return self._service
-        creds_path = Path(self._cfg.credentials_path)
-        if not creds_path.exists():
-            raise ExportError(f"Credentials file not found: {creds_path}")
 
-        from google.oauth2.service_account import Credentials
         from googleapiclient.discovery import build
 
-        creds = Credentials.from_service_account_file(
-            str(creds_path), scopes=_SCOPES
-        )
+        creds = self._load_oauth_credentials()
+        if creds is None:
+            creds = self._load_service_account_credentials()
+
         self._service = build(
             "drive", "v3", credentials=creds, cache_discovery=False
         )
         return self._service
 
-    def _md_to_html(self, minutes_md: str) -> str:
-        """Convert Markdown to HTML."""
+    def _build_docs_service(self) -> Any:
+        """Build and cache the Google Docs API v1 service client.
+
+        Reuses the same OAuth2/SA credential loading as _build_service().
+        drive.file scope is sufficient for Docs API operations on owned files.
+        """
+        if self._docs_service is not None:
+            return self._docs_service
+
+        from googleapiclient.discovery import build
+
+        creds = self._load_oauth_credentials()
+        if creds is None:
+            creds = self._load_service_account_credentials()
+
+        self._docs_service = build(
+            "docs", "v1", credentials=creds, cache_discovery=False
+        )
+        return self._docs_service
+
+    def _load_oauth_credentials(self) -> Any:
+        """Load OAuth2 user credentials from token.json."""
+        token_path = Path(self._cfg.oauth_token_path)
+        if not token_path.exists():
+            return None
+
+        try:
+            from google.auth.transport.requests import Request
+            from google.oauth2.credentials import Credentials
+
+            creds = Credentials.from_authorized_user_file(
+                str(token_path), _SCOPES
+            )
+            if creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+                token_path.write_text(creds.to_json())
+                logger.debug("OAuth token refreshed")
+            return creds
+        except Exception as exc:
+            logger.warning("Failed to load OAuth credentials: %s", exc)
+            return None
+
+    def _load_service_account_credentials(self) -> Any:
+        """Load service account credentials (fallback)."""
+        creds_path = Path(self._cfg.credentials_path)
+        if not creds_path.exists():
+            raise ExportError(f"Credentials file not found: {creds_path}")
+
+        from google.oauth2.service_account import Credentials
+
+        return Credentials.from_service_account_file(
+            str(creds_path), scopes=_SCOPES
+        )
+
+    def _md_to_html(
+        self,
+        minutes_md: str,
+        transcript_doc_url: str | None = None,
+    ) -> str:
+        """Convert Markdown to styled HTML mimicking Google Meet Gemini notes.
+
+        Google Docs ignores <style> tags, so all styling is applied inline.
+        The output format mirrors Google Meet's "Take notes for me" feature.
+        If *transcript_doc_url* is provided, timestamp references in the minutes
+        become clickable links pointing to the transcript document.
+        """
+        import re
+
         import markdown
 
         md = markdown.Markdown(extensions=["tables", "fenced_code"])
         body = md.convert(minutes_md)
+
+        # --- Inline styles (Google Docs ignores <style> blocks) ---
+
+        body = body.replace(
+            "<h1>",
+            '<h1 style="font-size:22pt;color:#202124;font-weight:normal;'
+            'margin-top:30px;margin-bottom:4px;">',
+        )
+        body = body.replace(
+            "<h2>",
+            '<h2 style="font-size:16pt;color:#202124;font-weight:normal;'
+            'margin-top:26px;margin-bottom:8px;">',
+        )
+        body = body.replace(
+            "<h3>",
+            '<h3 style="font-size:12pt;color:#202124;font-weight:bold;'
+            'margin-top:18px;margin-bottom:6px;">',
+        )
+        body = body.replace(
+            "<li>",
+            '<li style="margin-bottom:10px;line-height:1.6;">',
+        )
+        body = body.replace(
+            "<p>",
+            '<p style="line-height:1.6;margin-bottom:8px;color:#3c4043;">',
+        )
+        body = body.replace(
+            "<table>",
+            '<table style="border-collapse:collapse;width:100%;margin:12px 0;">',
+        )
+        body = body.replace(
+            "<th>",
+            '<th style="border:1px solid #dadce0;padding:8px 12px;'
+            'background-color:#f1f3f4;font-weight:bold;">',
+        )
+        body = body.replace(
+            "<td>",
+            '<td style="border:1px solid #dadce0;padding:8px 12px;">',
+        )
+
+        # Checkbox conversion
+        body = body.replace("[ ]", "\u2610")
+        body = body.replace("[x]", "\u2611")
+
+        # Convert timestamp references ([MM:SS]) to links to transcript doc
+        if transcript_doc_url:
+            def _link_timestamp(m: re.Match) -> str:
+                ts = m.group(1)
+                return (
+                    f'(<a href="{transcript_doc_url}" '
+                    f'style="color:#1a73e8;font-size:9pt;text-decoration:none;">'
+                    f"[{ts}]</a>)"
+                )
+
+            body = re.sub(
+                r"\(\[([\d:]+(?:\]-\[[\d:]+)?)\]\)",
+                _link_timestamp,
+                body,
+            )
+        else:
+            # No transcript doc — just style timestamps as blue text
+            body = re.sub(
+                r"\(\[([\d:]+(?:\]-\[[\d:]+)?)\]\)",
+                r'<span style="color:#1a73e8;font-size:9pt;">([\1])</span>',
+                body,
+            )
+
+        # Add transcript link if available
+        transcript_link = ""
+        if transcript_doc_url:
+            transcript_link = (
+                '<p style="margin-top:20px;">'
+                f'<a href="{transcript_doc_url}" '
+                'style="color:#1a73e8;text-decoration:none;font-size:10pt;">'
+                '\U0001f4d6 文字起こしを表示</a></p>'
+            )
+
+        # Add footer attribution
+        footer = (
+            f"{transcript_link}"
+            '<hr style="border:none;border-top:1px solid #dadce0;margin-top:30px;">'
+            '<p style="color:#80868b;font-size:9pt;line-height:1.4;">'
+            'Discord Minutes Bot による自動生成議事録です。'
+            ' 内容の正確性を確認してください。</p>'
+        )
+
         return (
             "<!DOCTYPE html>"
             '<html><head><meta charset="utf-8"></head>'
-            f"<body>{body}</body></html>"
+            '<body style="font-family:\'Google Sans\',\'Noto Sans JP\',sans-serif;'
+            f'font-size:11pt;color:#202124;line-height:1.6;">{body}{footer}'
+            "</body></html>"
         )
 
     def _upload_as_doc_sync(self, html: str, title: str) -> tuple[str, str]:
@@ -91,15 +251,261 @@ class GoogleDocsExporter:
         )
         return result["id"], result["webViewLink"]
 
+    # ------------------------------------------------------------------
+    # Docs API tab methods (Phase 2: 2-tab Gemini format)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _utf16_len(text: str) -> int:
+        """Count UTF-16 code units (Google Docs API character counting)."""
+        return len(text.encode("utf-16-le")) // 2
+
+    def _add_transcript_tab_sync(self, doc_id: str) -> str:
+        """Add a transcript tab to the document. Returns the new tabId."""
+        docs_service = self._build_docs_service()
+        result = docs_service.documents().batchUpdate(
+            documentId=doc_id,
+            body={
+                "requests": [
+                    {
+                        "addDocumentTab": {
+                            "tabProperties": {
+                                "title": "\U0001f4d6 文字起こし",
+                            }
+                        }
+                    }
+                ]
+            },
+        ).execute()
+        return result["replies"][0]["addDocumentTab"]["tabProperties"]["tabId"]
+
+    def _build_transcript_requests(
+        self, transcript_md: str, tab_id: str,
+    ) -> list[dict[str, Any]]:
+        """Convert transcript markdown to Google Docs API batchUpdate requests.
+
+        Parses line-by-line:
+          - ``# heading``        -> insertText + HEADING_1
+          - ``### HH:MM:SS``     -> insertText + HEADING_3
+          - ``**Speaker:** text`` -> insertText + bold for speaker name
+          - ``- metadata``       -> insertText (NORMAL_TEXT)
+          - plain text / blank   -> insertText (NORMAL_TEXT)
+
+        Returns ordered requests for forward insertion starting at index 1.
+        """
+        re_h1 = re.compile(r"^# (.+)$")
+        re_h3 = re.compile(r"^### (.+)$")
+        re_speaker = re.compile(r"^\*\*(.+?):\*\*\s*(.*)$")
+
+        requests: list[dict[str, Any]] = []
+        offset = 1  # New tab starts at index 1
+
+        lines = transcript_md.splitlines()
+        for line in lines:
+            m_h1 = re_h1.match(line)
+            m_h3 = re_h3.match(line)
+            m_speaker = re_speaker.match(line)
+
+            if m_h1:
+                text = m_h1.group(1) + "\n"
+                text_len = self._utf16_len(text)
+                requests.append({
+                    "insertText": {
+                        "text": text,
+                        "location": {"segmentId": "", "index": offset, "tabId": tab_id},
+                    }
+                })
+                requests.append({
+                    "updateParagraphStyle": {
+                        "paragraphStyle": {"namedStyleType": "HEADING_1"},
+                        "range": {
+                            "segmentId": "", "startIndex": offset,
+                            "endIndex": offset + text_len, "tabId": tab_id,
+                        },
+                        "fields": "namedStyleType",
+                    }
+                })
+                offset += text_len
+
+            elif m_h3:
+                text = m_h3.group(1) + "\n"
+                text_len = self._utf16_len(text)
+                requests.append({
+                    "insertText": {
+                        "text": text,
+                        "location": {"segmentId": "", "index": offset, "tabId": tab_id},
+                    }
+                })
+                requests.append({
+                    "updateParagraphStyle": {
+                        "paragraphStyle": {"namedStyleType": "HEADING_3"},
+                        "range": {
+                            "segmentId": "", "startIndex": offset,
+                            "endIndex": offset + text_len, "tabId": tab_id,
+                        },
+                        "fields": "namedStyleType",
+                    }
+                })
+                offset += text_len
+
+            elif m_speaker:
+                speaker = m_speaker.group(1) + ": "
+                spoken_text = m_speaker.group(2)
+                full_text = speaker + spoken_text + "\n"
+                text_len = self._utf16_len(full_text)
+                speaker_len = self._utf16_len(speaker)
+                requests.append({
+                    "insertText": {
+                        "text": full_text,
+                        "location": {"segmentId": "", "index": offset, "tabId": tab_id},
+                    }
+                })
+                requests.append({
+                    "updateTextStyle": {
+                        "textStyle": {"bold": True},
+                        "range": {
+                            "segmentId": "", "startIndex": offset,
+                            "endIndex": offset + speaker_len, "tabId": tab_id,
+                        },
+                        "fields": "bold",
+                    }
+                })
+                offset += text_len
+
+            else:
+                # Plain text, metadata lines (- 日時: ...), or blank lines
+                text = line + "\n" if line else "\n"
+                text_len = self._utf16_len(text)
+                requests.append({
+                    "insertText": {
+                        "text": text,
+                        "location": {"segmentId": "", "index": offset, "tabId": tab_id},
+                    }
+                })
+                offset += text_len
+
+        # Footer disclaimer
+        footer = (
+            "\n---\n"
+            "この文字起こしはコンピュータが生成したものであり、"
+            "誤りが含まれている可能性があります。\n"
+        )
+        footer_len = self._utf16_len(footer)
+        requests.append({
+            "insertText": {
+                "text": footer,
+                "location": {"segmentId": "", "index": offset, "tabId": tab_id},
+            }
+        })
+        requests.append({
+            "updateTextStyle": {
+                "textStyle": {
+                    "italic": True,
+                    "foregroundColor": {
+                        "color": {
+                            "rgbColor": {"red": 0.502, "green": 0.525, "blue": 0.545}
+                        }
+                    },
+                    "fontSize": {"magnitude": 9, "unit": "PT"},
+                },
+                "range": {
+                    "segmentId": "", "startIndex": offset,
+                    "endIndex": offset + footer_len, "tabId": tab_id,
+                },
+                "fields": "italic,foregroundColor,fontSize",
+            }
+        })
+
+        return requests
+
+    def _write_transcript_content_sync(
+        self, doc_id: str, tab_id: str, transcript_md: str,
+    ) -> None:
+        """Write formatted transcript content into the specified tab."""
+        requests = self._build_transcript_requests(transcript_md, tab_id)
+        if not requests:
+            return
+
+        # Google Docs API allows up to 200 requests per batchUpdate
+        batch_size = 200
+        docs_service = self._build_docs_service()
+        for i in range(0, len(requests), batch_size):
+            chunk = requests[i : i + batch_size]
+            docs_service.documents().batchUpdate(
+                documentId=doc_id,
+                body={"requests": chunk},
+            ).execute()
+
+    def _update_timestamp_links_sync(
+        self, doc_id: str, tab_id: str, doc_url: str,
+    ) -> None:
+        """Replace placeholder URLs with actual tab links in the memo tab."""
+        target_url = f"{doc_url}?tab={tab_id}"
+        docs_service = self._build_docs_service()
+        docs_service.documents().batchUpdate(
+            documentId=doc_id,
+            body={
+                "requests": [
+                    {
+                        "replaceAllText": {
+                            "containsText": {
+                                "text": TRANSCRIPT_TAB_PLACEHOLDER,
+                                "matchCase": True,
+                            },
+                            "replaceText": target_url,
+                            "tabsCriteria": {"tabIds": ["t.0"]},
+                        }
+                    }
+                ]
+            },
+        ).execute()
+
+    def _rename_default_tab_sync(self, doc_id: str) -> None:
+        """Rename the default tab from 'Tab 1' to '📝 メモ'."""
+        docs_service = self._build_docs_service()
+        docs_service.documents().batchUpdate(
+            documentId=doc_id,
+            body={
+                "requests": [
+                    {
+                        "updateDocumentTab": {
+                            "tabProperties": {
+                                "tabId": "t.0",
+                                "title": "\U0001f4dd メモ",
+                            },
+                            "fields": "title",
+                        }
+                    }
+                ]
+            },
+        ).execute()
+
     async def export(
         self,
         minutes_md: str,
         title: str,
         metadata: dict[str, str] | None = None,
+        transcript_md: str | None = None,
     ) -> ExportResult:
-        """Export minutes to Google Docs. Never raises - returns ExportResult."""
-        html = self._md_to_html(minutes_md)
+        """Export minutes to Google Docs with optional transcript tab.
+
+        Hybrid approach:
+          Step 1: Drive API HTML upload → memo tab (default t.0)
+          Step 2: Docs API addDocumentTab → 文字起こし tab
+          Step 3: Docs API insertText + styles → transcript content
+          Fallback: Steps 2-3 fail → memo-only doc (current behavior)
+
+        Never raises — returns ExportResult.
+        """
+        # Step 1: Upload minutes as HTML (existing logic with retry)
+        # Use placeholder URL for timestamps if transcript will be in a tab
+        html = self._md_to_html(
+            minutes_md,
+            transcript_doc_url=TRANSCRIPT_TAB_PLACEHOLDER if transcript_md else None,
+        )
         last_error = None
+        doc_id: str | None = None
+        url: str | None = None
 
         for attempt in range(1, self._cfg.max_retries + 1):
             try:
@@ -113,7 +519,7 @@ class GoogleDocsExporter:
                     elapsed,
                     url,
                 )
-                return ExportResult(success=True, url=url, doc_id=doc_id)
+                break
             except Exception as exc:
                 last_error = str(exc)
                 logger.warning(
@@ -122,7 +528,6 @@ class GoogleDocsExporter:
                     self._cfg.max_retries,
                     exc,
                 )
-                # Check for non-retryable HTTP errors
                 if hasattr(exc, "resp") and hasattr(exc.resp, "status"):
                     status = exc.resp.status
                     if 400 <= status < 500 and status not in (403, 429):
@@ -131,9 +536,52 @@ class GoogleDocsExporter:
                     delay = 2 ** (attempt - 1)
                     await asyncio.sleep(delay)
 
-        logger.error(
-            "Export failed after %d attempts: %s",
-            self._cfg.max_retries,
-            last_error,
-        )
-        return ExportResult(success=False, error=last_error)
+        if doc_id is None:
+            logger.error(
+                "Export failed after %d attempts: %s",
+                self._cfg.max_retries,
+                last_error,
+            )
+            return ExportResult(success=False, error=last_error)
+
+        # Steps 2-4: Add transcript tab + content + links (non-critical)
+        if not transcript_md:
+            logger.info("No transcript_md provided; skipping tab creation")
+        else:
+            tab_created = False
+            try:
+                tab_id = await asyncio.to_thread(
+                    self._add_transcript_tab_sync, doc_id,
+                )
+                tab_created = True
+
+                await asyncio.to_thread(
+                    self._write_transcript_content_sync,
+                    doc_id, tab_id, transcript_md,
+                )
+                await asyncio.to_thread(
+                    self._update_timestamp_links_sync, doc_id, tab_id, url,
+                )
+                # Rename default tab to "📝 メモ" on full success
+                try:
+                    await asyncio.to_thread(
+                        self._rename_default_tab_sync, doc_id,
+                    )
+                except Exception as exc:
+                    logger.warning("Tab rename failed (non-critical): %s", exc)
+
+                logger.info(
+                    "2-tab doc created: doc=%s memo=t.0 transcript=%s",
+                    doc_id, tab_id,
+                )
+            except Exception as exc:
+                if tab_created:
+                    logger.warning(
+                        "Transcript tab added but content/links failed: %s", exc,
+                    )
+                else:
+                    logger.warning(
+                        "Transcript tab creation failed, memo-only doc: %s", exc,
+                    )
+
+        return ExportResult(success=True, url=url, doc_id=doc_id)

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -143,9 +143,9 @@ async def run_pipeline_from_tracks(
             speakers_str = ", ".join(speaker_names)
             date_str = datetime.now().strftime("%Y-%m-%d %H:%M")
 
-            # Prepare transcript markdown for attachment (if enabled)
+            # Prepare transcript markdown for attachment or Google Docs tab
             transcript_md: str | None = None
-            if cfg.poster.include_transcript:
+            if cfg.poster.include_transcript or cfg.export_google_docs.enabled:
                 transcript_md = format_transcript_markdown(
                     transcript, date_str, speakers_str,
                 )
@@ -215,6 +215,7 @@ async def run_pipeline_from_tracks(
                         minutes_md=minutes_md,
                         title=title,
                         metadata={"date": date_str, "speakers": speakers_str, "source": source_label},
+                        transcript_md=transcript_md,
                     )
                     if export_result.success:
                         logger.info("Minutes exported to Google Docs: %s", export_result.url)

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -17,6 +17,8 @@ from src.exporter import ExportResult, GoogleDocsExporter
 _CFG = SimpleNamespace(
     enabled=True,
     credentials_path="credentials.json",
+    oauth_client_path="oauth_client.json",
+    oauth_token_path="token.json",
     folder_id="test-folder-id",
     max_retries=3,
 )
@@ -40,8 +42,8 @@ class TestMdToHtml:
     def test_md_to_html_headings(self) -> None:
         exp = _make_exporter()
         html = exp._md_to_html("# Heading 1\n\n## Heading 2")
-        assert "<h1>" in html and "Heading 1" in html
-        assert "<h2>" in html and "Heading 2" in html
+        assert "<h1 " in html and "Heading 1" in html
+        assert "<h2 " in html and "Heading 2" in html
 
     def test_md_to_html_bold(self) -> None:
         exp = _make_exporter()
@@ -53,7 +55,7 @@ class TestMdToHtml:
         md_text = "- item one\n- item two\n- item three"
         html = exp._md_to_html(md_text)
         assert "<ul>" in html
-        assert "<li>" in html
+        assert "<li " in html
         assert "item one" in html
         assert "item two" in html
         assert "item three" in html
@@ -67,8 +69,8 @@ class TestMdToHtml:
             | Bob     | 05:30    |
         """)
         html = exp._md_to_html(md_table)
-        assert "<table>" in html
-        assert "<th>" in html or "<td>" in html
+        assert "<table " in html
+        assert "<th " in html or "<td " in html
         assert "Alice" in html
         assert "Bob" in html
 
@@ -111,13 +113,13 @@ class TestMdToHtml:
         """)
         html = exp._md_to_html(md)
 
-        # Structural checks
-        assert "<h1>" in html
-        assert "<h2>" in html
-        assert "<h3>" in html
+        # Structural checks (tags have inline styles, so check prefix)
+        assert "<h1 " in html
+        assert "<h2 " in html
+        assert "<h3 " in html
         assert "<ul>" in html
-        assert "<li>" in html
-        assert "<table>" in html
+        assert "<li " in html
+        assert "<table " in html
         assert "<strong>" in html
 
         # Content checks
@@ -134,7 +136,7 @@ class TestMdToHtml:
         assert html.startswith("<!DOCTYPE html>")
         assert "<html>" in html
         assert '<meta charset="utf-8">' in html
-        assert "<body>" in html
+        assert "<body " in html
         assert "</body></html>" in html
 
 
@@ -248,6 +250,7 @@ class TestExportRetry:
         cfg = SimpleNamespace(
             enabled=True,
             credentials_path="credentials.json",
+            oauth_token_path="token.json",
             folder_id="test-folder-id",
             max_retries=3,
         )
@@ -318,6 +321,7 @@ class TestBuildService:
         cfg = SimpleNamespace(
             enabled=True,
             credentials_path=str(tmp_path / "nonexistent-creds.json"),
+            oauth_token_path=str(tmp_path / "nonexistent-token.json"),
             folder_id="test-folder-id",
             max_retries=3,
         )
@@ -336,6 +340,7 @@ class TestBuildService:
         cfg = SimpleNamespace(
             enabled=True,
             credentials_path=str(creds_file),
+            oauth_token_path=str(tmp_path / "nonexistent-token.json"),
             folder_id="test-folder-id",
             max_retries=3,
         )
@@ -358,6 +363,479 @@ class TestBuildService:
 # ===================================================================
 # ExportResult dataclass
 # ===================================================================
+
+
+class TestBuildDocsService:
+    """Tests for GoogleDocsExporter._build_docs_service."""
+
+    def test_build_docs_service_builds_docs_api(self, tmp_path) -> None:
+        """Docs service is built with API name 'docs' and version 'v1'."""
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text("{}", encoding="utf-8")
+
+        cfg = SimpleNamespace(
+            enabled=True,
+            credentials_path=str(creds_file),
+            oauth_token_path=str(tmp_path / "nonexistent-token.json"),
+            folder_id="test-folder-id",
+            max_retries=3,
+        )
+        exp = _make_exporter(cfg)
+
+        with patch("google.oauth2.service_account.Credentials") as mock_creds_cls, \
+             patch("googleapiclient.discovery.build") as mock_build:
+            mock_creds_cls.from_service_account_file.return_value = MagicMock()
+            mock_build.return_value = MagicMock()
+
+            exp._build_docs_service()
+
+            mock_build.assert_called_once_with(
+                "docs", "v1", credentials=mock_creds_cls.from_service_account_file.return_value,
+                cache_discovery=False,
+            )
+
+    def test_build_docs_service_caching(self, tmp_path) -> None:
+        """Docs service is built once and cached on subsequent calls."""
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text("{}", encoding="utf-8")
+
+        cfg = SimpleNamespace(
+            enabled=True,
+            credentials_path=str(creds_file),
+            oauth_token_path=str(tmp_path / "nonexistent-token.json"),
+            folder_id="test-folder-id",
+            max_retries=3,
+        )
+        exp = _make_exporter(cfg)
+
+        with patch("google.oauth2.service_account.Credentials") as mock_creds_cls, \
+             patch("googleapiclient.discovery.build") as mock_build:
+            mock_creds_cls.from_service_account_file.return_value = MagicMock()
+            mock_build.return_value = MagicMock()
+
+            service1 = exp._build_docs_service()
+            service2 = exp._build_docs_service()
+
+            assert service1 is service2
+            mock_build.assert_called_once()
+
+    def test_build_docs_service_independent_of_drive(self, tmp_path) -> None:
+        """Docs service is cached separately from Drive service."""
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text("{}", encoding="utf-8")
+
+        cfg = SimpleNamespace(
+            enabled=True,
+            credentials_path=str(creds_file),
+            oauth_token_path=str(tmp_path / "nonexistent-token.json"),
+            folder_id="test-folder-id",
+            max_retries=3,
+        )
+        exp = _make_exporter(cfg)
+
+        with patch("google.oauth2.service_account.Credentials") as mock_creds_cls, \
+             patch("googleapiclient.discovery.build") as mock_build:
+            mock_creds_cls.from_service_account_file.return_value = MagicMock()
+            mock_build.side_effect = [MagicMock(name="drive"), MagicMock(name="docs")]
+
+            drive = exp._build_service()
+            docs = exp._build_docs_service()
+
+            assert drive is not docs
+            assert mock_build.call_count == 2
+
+
+# ===================================================================
+# Docs API tab creation (Phase 2)
+# ===================================================================
+
+
+def _mock_docs_service(tab_id: str = "t.test123"):
+    """Create a mock Google Docs API v1 service."""
+    mock_execute = MagicMock(return_value={
+        "replies": [{
+            "addDocumentTab": {
+                "tabProperties": {
+                    "tabId": tab_id,
+                    "title": "\U0001f4d6 文字起こし",
+                    "index": 1,
+                }
+            }
+        }],
+        "documentId": "doc-123",
+    })
+    mock_batch = MagicMock()
+    mock_batch.return_value.execute = mock_execute
+    mock_documents = MagicMock()
+    mock_documents.return_value.batchUpdate = mock_batch
+    service = MagicMock()
+    service.documents = mock_documents
+    return service
+
+
+_SAMPLE_TRANSCRIPT = """\
+# 文字起こし
+- 日時: 2026-03-20 14:00
+- 参加者: Alice, Bob
+
+### 00:00:00
+
+**Alice:** こんにちは、今日の議題について話しましょう。
+**Bob:** はい、まずプロジェクトの進捗から。
+
+### 00:03:00
+
+**Alice:** フロントエンドの実装が完了しました。
+"""
+
+
+class TestTranscriptTab:
+    """Tests for transcript tab creation and content writing."""
+
+    def test_add_transcript_tab_success(self) -> None:
+        """Tab creation returns the new tabId."""
+        exp = _make_exporter()
+        exp._docs_service = _mock_docs_service(tab_id="t.abc123")
+
+        tab_id = exp._add_transcript_tab_sync("doc-123")
+        assert tab_id == "t.abc123"
+
+    def test_add_transcript_tab_sets_title(self) -> None:
+        """Tab creation request uses the correct Japanese title."""
+        exp = _make_exporter()
+        exp._docs_service = _mock_docs_service()
+
+        exp._add_transcript_tab_sync("doc-123")
+
+        call_args = exp._docs_service.documents().batchUpdate.call_args
+        requests = call_args[1]["body"]["requests"] if "body" in call_args[1] else call_args[0][0]["requests"]
+        tab_props = requests[0]["addDocumentTab"]["tabProperties"]
+        assert tab_props["title"] == "\U0001f4d6 文字起こし"
+
+    def test_build_transcript_heading_style(self) -> None:
+        """H3 timestamps generate HEADING_3 paragraph style."""
+        exp = _make_exporter()
+        requests = exp._build_transcript_requests("### 00:03:00", "t.test")
+
+        # Find updateParagraphStyle request
+        heading_reqs = [r for r in requests if "updateParagraphStyle" in r]
+        assert len(heading_reqs) >= 1
+        style = heading_reqs[0]["updateParagraphStyle"]
+        assert style["paragraphStyle"]["namedStyleType"] == "HEADING_3"
+
+    def test_build_transcript_h1_style(self) -> None:
+        """H1 generates HEADING_1 paragraph style."""
+        exp = _make_exporter()
+        requests = exp._build_transcript_requests("# 文字起こし", "t.test")
+
+        heading_reqs = [r for r in requests if "updateParagraphStyle" in r]
+        assert len(heading_reqs) >= 1
+        assert heading_reqs[0]["updateParagraphStyle"]["paragraphStyle"]["namedStyleType"] == "HEADING_1"
+
+    def test_build_transcript_bold_speaker(self) -> None:
+        """Speaker names are bolded."""
+        exp = _make_exporter()
+        requests = exp._build_transcript_requests("**Alice:** Hello world", "t.test")
+
+        bold_reqs = [r for r in requests if "updateTextStyle" in r and r["updateTextStyle"].get("textStyle", {}).get("bold")]
+        assert len(bold_reqs) >= 1
+        bold_range = bold_reqs[0]["updateTextStyle"]["range"]
+        # "Alice: " is 7 chars
+        assert bold_range["endIndex"] - bold_range["startIndex"] == 7
+
+    def test_build_transcript_footer_style(self) -> None:
+        """Footer generates italic + gray color style."""
+        exp = _make_exporter()
+        requests = exp._build_transcript_requests("", "t.test")
+
+        # Footer is always appended (even for empty transcript)
+        italic_reqs = [r for r in requests if "updateTextStyle" in r and r["updateTextStyle"].get("textStyle", {}).get("italic")]
+        assert len(italic_reqs) >= 1
+        style = italic_reqs[0]["updateTextStyle"]["textStyle"]
+        assert style["italic"] is True
+        assert "foregroundColor" in style
+
+    def test_build_transcript_empty_md(self) -> None:
+        """Empty transcript produces only footer requests."""
+        exp = _make_exporter()
+        requests = exp._build_transcript_requests("", "t.test")
+
+        insert_reqs = [r for r in requests if "insertText" in r]
+        # Should have at least the empty line + footer
+        assert len(insert_reqs) >= 1
+
+    def test_build_transcript_tab_id_scoping(self) -> None:
+        """All requests include the correct tabId."""
+        exp = _make_exporter()
+        requests = exp._build_transcript_requests(_SAMPLE_TRANSCRIPT, "t.myid")
+
+        for req in requests:
+            if "insertText" in req:
+                assert req["insertText"]["location"]["tabId"] == "t.myid"
+            elif "updateParagraphStyle" in req:
+                assert req["updateParagraphStyle"]["range"]["tabId"] == "t.myid"
+            elif "updateTextStyle" in req:
+                assert req["updateTextStyle"]["range"]["tabId"] == "t.myid"
+
+    def test_build_transcript_offset_tracking(self) -> None:
+        """Offsets are tracked correctly across multiple lines."""
+        exp = _make_exporter()
+        md = "# Title\n**Alice:** Hi\n**Bob:** Hey"
+        requests = exp._build_transcript_requests(md, "t.test")
+
+        # Verify insertText requests have increasing, non-overlapping offsets
+        insert_reqs = [r["insertText"] for r in requests if "insertText" in r]
+        prev_end = 1  # starts at 1
+        for req in insert_reqs:
+            idx = req["location"]["index"]
+            assert idx >= prev_end, f"Insert at {idx} overlaps previous end {prev_end}"
+            prev_end = idx + exp._utf16_len(req["text"])
+
+    def test_build_transcript_unicode_offset(self) -> None:
+        """Japanese characters count correctly (1 UTF-16 code unit each)."""
+        exp = _make_exporter()
+        assert exp._utf16_len("こんにちは") == 5
+        assert exp._utf16_len("Hello") == 5
+        # Emoji (surrogate pair)
+        assert exp._utf16_len("\U0001f4d6") == 2
+
+    @pytest.mark.asyncio
+    async def test_export_creates_tab_on_success(self) -> None:
+        """Full export with transcript_md creates a 2-tab document."""
+        exp = _make_exporter()
+        exp._service = _mock_drive_service(doc_id="doc-abc", url="https://docs.google.com/document/d/doc-abc/edit")
+        exp._docs_service = _mock_docs_service(tab_id="t.xyz789")
+
+        result = await exp.export(
+            "# Minutes", "Test Meeting",
+            transcript_md=_SAMPLE_TRANSCRIPT,
+        )
+
+        assert result.success is True
+        assert result.doc_id == "doc-abc"
+        # Verify Docs API was called (tab creation + content write)
+        assert exp._docs_service.documents().batchUpdate.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_export_tab_failure_still_succeeds(self) -> None:
+        """Tab creation failure doesn't affect overall export success."""
+        exp = _make_exporter()
+        exp._service = _mock_drive_service(doc_id="doc-abc", url="https://docs.google.com/document/d/doc-abc/edit")
+
+        # Docs service that always fails
+        mock_docs = MagicMock()
+        mock_docs.documents().batchUpdate.return_value.execute.side_effect = RuntimeError("Docs API down")
+        exp._docs_service = mock_docs
+
+        result = await exp.export(
+            "# Minutes", "Test Meeting",
+            transcript_md=_SAMPLE_TRANSCRIPT,
+        )
+
+        assert result.success is True
+        assert result.doc_id == "doc-abc"
+
+    @pytest.mark.asyncio
+    async def test_export_no_transcript_skips_tab(self) -> None:
+        """Export without transcript_md skips tab creation entirely."""
+        exp = _make_exporter()
+        exp._service = _mock_drive_service()
+        exp._docs_service = _mock_docs_service()
+
+        result = await exp.export("# Minutes", "Test Meeting")
+
+        assert result.success is True
+        # Docs API should NOT be called
+        exp._docs_service.documents().batchUpdate.assert_not_called()
+
+
+# ===================================================================
+# Timestamp cross-tab links (Phase 3)
+# ===================================================================
+
+
+class TestTimestampLinks:
+    """Tests for cross-tab timestamp link replacement."""
+
+    def test_md_to_html_timestamp_placeholder(self) -> None:
+        """Timestamps become links with placeholder URL when transcript URL provided."""
+        from src.exporter import TRANSCRIPT_TAB_PLACEHOLDER
+        exp = _make_exporter()
+        md = "Some discussion ([12:34])"
+        html = exp._md_to_html(md, transcript_doc_url=TRANSCRIPT_TAB_PLACEHOLDER)
+
+        assert TRANSCRIPT_TAB_PLACEHOLDER in html
+        assert "12:34" in html
+
+    def test_update_timestamp_links_calls_replace_all(self) -> None:
+        """Verify replaceAllText request structure."""
+        from src.exporter import TRANSCRIPT_TAB_PLACEHOLDER
+        exp = _make_exporter()
+        exp._docs_service = _mock_docs_service()
+
+        exp._update_timestamp_links_sync(
+            "doc-123", "t.abc456", "https://docs.google.com/document/d/doc-123/edit",
+        )
+
+        call_args = exp._docs_service.documents().batchUpdate.call_args
+        body = call_args[1]["body"] if "body" in call_args[1] else call_args[0][0]
+        req = body["requests"][0]["replaceAllText"]
+        assert req["containsText"]["text"] == TRANSCRIPT_TAB_PLACEHOLDER
+        assert "?tab=t.abc456" in req["replaceText"]
+        assert req["tabsCriteria"]["tabIds"] == ["t.0"]
+
+    @pytest.mark.asyncio
+    async def test_export_updates_links_after_tab_creation(self) -> None:
+        """Full flow: link update is called after tab creation."""
+        from src.exporter import TRANSCRIPT_TAB_PLACEHOLDER
+        exp = _make_exporter()
+        exp._service = _mock_drive_service(doc_id="doc-abc", url="https://docs.google.com/document/d/doc-abc/edit")
+        exp._docs_service = _mock_docs_service(tab_id="t.link123")
+
+        result = await exp.export(
+            "Discussion ([12:34])", "Test Meeting",
+            transcript_md=_SAMPLE_TRANSCRIPT,
+        )
+
+        assert result.success is True
+        # At least 3 batchUpdate calls: addTab + writeContent + replaceAllText
+        assert exp._docs_service.documents().batchUpdate.call_count >= 3
+
+
+# ===================================================================
+# Fallback behavior (Phase 4)
+# ===================================================================
+
+
+class TestFallbackBehavior:
+    """Tests for graceful degradation when Docs API fails."""
+
+    @pytest.mark.asyncio
+    async def test_export_no_transcript_md_skips_tab(self) -> None:
+        """transcript_md=None skips all Docs API calls."""
+        exp = _make_exporter()
+        exp._service = _mock_drive_service()
+        exp._docs_service = _mock_docs_service()
+
+        result = await exp.export("# Minutes", "Test Meeting", transcript_md=None)
+
+        assert result.success is True
+        exp._docs_service.documents().batchUpdate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_export_tab_creation_failure_returns_success(self) -> None:
+        """addDocumentTab raises → memo-only doc, success=True."""
+        exp = _make_exporter()
+        exp._service = _mock_drive_service()
+
+        mock_docs = MagicMock()
+        mock_docs.documents().batchUpdate.return_value.execute.side_effect = RuntimeError("addDocumentTab failed")
+        exp._docs_service = mock_docs
+
+        result = await exp.export("# Minutes", "Test", transcript_md=_SAMPLE_TRANSCRIPT)
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_export_content_write_failure_logs_warning(self) -> None:
+        """Content write failure → tab exists but empty, success=True."""
+        exp = _make_exporter()
+        exp._service = _mock_drive_service()
+
+        call_count = 0
+        def batch_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call (addDocumentTab) succeeds
+                return {
+                    "replies": [{"addDocumentTab": {"tabProperties": {"tabId": "t.test", "title": "x", "index": 1}}}],
+                    "documentId": "doc-123",
+                }
+            # Second call (writeContent) fails
+            raise RuntimeError("write failed")
+
+        mock_docs = MagicMock()
+        mock_docs.documents().batchUpdate.return_value.execute.side_effect = batch_side_effect
+        exp._docs_service = mock_docs
+
+        result = await exp.export("# Minutes", "Test", transcript_md=_SAMPLE_TRANSCRIPT)
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_export_link_update_failure_logs_warning(self) -> None:
+        """replaceAllText failure → tabs exist with content, success=True."""
+        exp = _make_exporter()
+        exp._service = _mock_drive_service()
+
+        call_count = 0
+        def batch_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # addDocumentTab
+                return {
+                    "replies": [{"addDocumentTab": {"tabProperties": {"tabId": "t.test", "title": "x", "index": 1}}}],
+                    "documentId": "doc-123",
+                }
+            if call_count == 2:
+                # writeContent
+                return {"replies": [], "documentId": "doc-123"}
+            # replaceAllText (3rd call) fails
+            raise RuntimeError("replace failed")
+
+        mock_docs = MagicMock()
+        mock_docs.documents().batchUpdate.return_value.execute.side_effect = batch_side_effect
+        exp._docs_service = mock_docs
+
+        result = await exp.export("# Minutes", "Test", transcript_md=_SAMPLE_TRANSCRIPT)
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_export_rename_tab_failure_nonfatal(self) -> None:
+        """updateDocumentTab rename failure → tabs work, default name remains."""
+        exp = _make_exporter()
+        exp._service = _mock_drive_service()
+
+        call_count = 0
+        def batch_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # addDocumentTab
+                return {
+                    "replies": [{"addDocumentTab": {"tabProperties": {"tabId": "t.test", "title": "x", "index": 1}}}],
+                    "documentId": "doc-123",
+                }
+            if call_count <= 3:
+                # writeContent + replaceAllText
+                return {"replies": [], "documentId": "doc-123"}
+            # renameTab (4th call) fails
+            raise RuntimeError("rename failed")
+
+        mock_docs = MagicMock()
+        mock_docs.documents().batchUpdate.return_value.execute.side_effect = batch_side_effect
+        exp._docs_service = mock_docs
+
+        result = await exp.export("# Minutes", "Test", transcript_md=_SAMPLE_TRANSCRIPT)
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_export_html_upload_failure_returns_failure(self) -> None:
+        """Step 1 (HTML upload) fails → ExportResult(success=False)."""
+        exp = _make_exporter()
+
+        mock_execute = MagicMock(side_effect=ConnectionError("network down"))
+        mock_create = MagicMock()
+        mock_create.return_value.execute = mock_execute
+        mock_files = MagicMock()
+        mock_files.return_value.create = mock_create
+        service = MagicMock()
+        service.files = mock_files
+        exp._service = service
+
+        result = await exp.export("# Minutes", "Test", transcript_md=_SAMPLE_TRANSCRIPT)
+        assert result.success is False
+        assert "network down" in result.error
 
 
 class TestExportResult:


### PR DESCRIPTION
## Summary

- Google Docs エクスポートを、Google Meet Gemini の「メモを取って」機能のフォーマットに準拠した **2タブ構成（📝 メモ + 📖 文字起こし）** に刷新
- 既存の別ドキュメント方式（議事録 + 文字起こしが別ファイル）を、1つのGoogle Doc内のタブに統合
- Docs API 失敗時は自動的にメモ単体ドキュメントにフォールバック（既存動作を維持）

## Changes

- **`src/exporter.py`**: Docs API v1 サービスビルダー、タブ作成/コンテンツ書き込み/タイムスタンプリンク更新/タブリネームの7メソッド追加、`export()` を2タブフローに書き換え、deprecated `_transcript_to_html()` 削除
- **`src/pipeline.py`**: `transcript_md` を `export_google_docs.enabled` 時にも生成するよう条件拡張（1行変更）
- **`tests/test_exporter.py`**: 25件の新規テスト追加（Docs API サービス、タブ作成、フォーマット、オフセット追跡、タイムスタンプリンク、フォールバック6シナリオ）、既存テストのインラインスタイル対応修正

## Architecture

```
export() → Step 1: Drive HTML upload (メモタブ t.0)
         → Step 2: addDocumentTab (📖 文字起こしタブ)
         → Step 3: insertText + styles (タブ内容書き込み)
         → Step 4: replaceAllText (タイムスタンプリンク更新)
         → Step 5: updateDocumentTab (📝 メモにリネーム)
         → Fallback: Steps 2-5 失敗 → メモ単体ドキュメント
```

## Test plan

- [x] 全42件の exporter テスト PASS
- [x] 全20件の pipeline テスト PASS
- [x] フルテストスイート 390 passed（GPU テスト2件は環境依存で既存の失敗）
- [ ] 実環境で2タブドキュメント生成を目視確認
- [ ] タイムスタンプクリックで文字起こしタブに遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)